### PR TITLE
add pep-561 marker file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE.txt
+include pure_eval/py.typed

--- a/pure_eval/py.typed
+++ b/pure_eval/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The pure_eval package uses inline types.

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,6 @@ setup_requires = setuptools>=44; wheel; setuptools_scm[toml]>=3.4.3
 
 [options.extras_require]
 tests = pytest
+
+[options.package_data]
+pure_eval = py.typed


### PR DESCRIPTION
This PR adds [PEP 561](https://www.python.org/dev/peps/pep-0561/) support for `pure_eval`. The rationale for this PR is that with the current 0.2.1 release, the type checks with `mypy` fail because `pure_eval` doesn't report having any type hints. A simple example to demonstrate:

```py
import inspect
from pure_eval import Evaluator

evaluator = Evaluator.from_frame(inspect.currentframe())
```
Installing `pure_eval` from PyPI and analyzing the snippet yields unavailable type hints:

```sh
$ pip install pure-eval==0.2.1 --no-cache-dir
...
$ mypy spam.py 
spam.py:2: error: Skipping analyzing "pure_eval": found module but no type hints or library stubs
spam.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```
Adding the `py.typed` marker manually (or installing from this PR!) now yields the expected type checking error:
```sh
$ touch $(python -c "import pure_eval; print(pure_eval.__path__[0])")/py.typed
$ mypy spam.py 
spam.py:4: error: Argument 1 to "from_frame" of "Evaluator" has incompatible type "Optional[FrameType]"; expected "FrameType"
Found 1 error in 1 file (checked 1 source file)
```