### PR TITLE
Use extras in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py{35,36,37,38,39}
 
 [testenv]
 commands = pytest
-deps =
-    .[tests]
+extras = tests
 passenv =
     PURE_EVAL_SLOW_TESTS


### PR DESCRIPTION
`extras` is more readable than `.[tests]` and we are parsing it in our automation when building RPM packages for Fedora.