### PR TITLE
Fix compatibility of check_copy_ast_without_context with Py 3.13b1

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,7 +58,16 @@ def check_copy_ast_without_context(tree):
     dump1 = ast.dump(tree)
     dump2 = ast.dump(tree2)
     normalised_dump1 = re.sub(
-        r", ctx=(Load|Store|Del)\(\)",
+        # Two possible matches:
+        # - first one like ", ctx=…" where ", " should be removed
+        # - second one like "(ctx=…" where "(" should be kept
+        (
+            r"("
+                r", ctx=(Load|Store|Del)\(\)"
+            r"|"
+                r"(?<=\()ctx=(Load|Store|Del)\(\)"
+            r")"
+        ),
         "",
         dump1
     )


### PR DESCRIPTION
Resolves: https://github.com/alexmojaki/pure_eval/issues/16

I've tried to split the regex for better readability but feel free to tell me your preference.