### PR TITLE
Specify exports in `__all__` to prevent `pyright` errors

### DIFF
--- a/pure_eval/__init__.py
+++ b/pure_eval/__init__.py
@@ -6,3 +6,11 @@ try:
 except ImportError:
     # version.py is auto-generated with the git tag when building
     __version__ = "???"
+
+__all__ = [
+    "Evaluator",
+    "CannotEval",
+    "group_expressions",
+    "is_expression_interesting",
+    "getattr_static",
+]


### PR DESCRIPTION
I used `pure_eval` in one of my projects, which uses `pyright` for type checking. But it seems if a module has a `py.typed` file in its root, `pyright` will only uses its `__all__` for exports, instead of infering.

This PR simply adds a `__all__` entry to fix this. May we can have a -post release for this? Thanks!